### PR TITLE
Remove wp_enqueue_script versioning

### DIFF
--- a/public/themes/wordplate/functions.php
+++ b/public/themes/wordplate/functions.php
@@ -20,12 +20,12 @@ add_action('wp_enqueue_scripts', function () {
         wp_get_environment_type() === 'local' &&
         is_array(wp_remote_get('http://localhost:5173/')) // is Vite.js running
     ) {
-        wp_enqueue_script('vite', 'http://localhost:5173/@vite/client');
-        wp_enqueue_script('wordplate', 'http://localhost:5173/resources/js/index.js');
+        wp_enqueue_script('vite', 'http://localhost:5173/@vite/client', [], null);
+        wp_enqueue_script('wordplate', 'http://localhost:5173/resources/js/index.js', [], null);
     } elseif (file_exists($manifestPath)) {
         $manifest = json_decode(file_get_contents($manifestPath), true);
-        wp_enqueue_script('wordplate', get_theme_file_uri('assets/' . $manifest['resources/js/index.js']['file']));
-        wp_enqueue_style('wordplate', get_theme_file_uri('assets/' . $manifest['resources/js/index.css']['file']));
+        wp_enqueue_script('wordplate', get_theme_file_uri('assets/' . $manifest['resources/js/index.js']['file']), [], null);
+        wp_enqueue_style('wordplate', get_theme_file_uri('assets/' . $manifest['resources/js/index.css']['file']), [], null);
     }
 });
 


### PR DESCRIPTION
Since we are using Vite versioning alongside the `manifest.json`, the `wp_enqueue_script` versioning is not needed, just noisy and telling the world the WordPress version we are in. Besides, on development the versioning on the vite client script raises a console error `Uncaught ReferenceError: __SERVER_HOST__ is not defined`