### PR TITLE
Treat CSS as independent input (opinionated)

### DIFF
--- a/public/themes/wordplate/functions.php
+++ b/public/themes/wordplate/functions.php
@@ -22,6 +22,7 @@ add_action('wp_enqueue_scripts', function () {
     ) {
         wp_enqueue_script('vite', 'http://localhost:5173/@vite/client');
         wp_enqueue_script('wordplate', 'http://localhost:5173/resources/js/index.js');
+        wp_enqueue_style('wordplate', 'http://localhost:5173/resources/css/index.css', [], null);
     } elseif (file_exists($manifestPath)) {
         $manifest = json_decode(file_get_contents($manifestPath), true);
         wp_enqueue_script('wordplate', get_theme_file_uri('assets/' . $manifest['resources/js/index.js']['file']));

--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -1,1 +1,1 @@
-import '../css/index.css';
+

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,7 +10,10 @@ export default defineConfig(() => ({
     manifest: true,
     outDir: `public/themes/${process.env.WP_DEFAULT_THEME}/assets`,
     rollupOptions: {
-      input: 'resources/js/index.js',
+      input: [
+        'resources/js/index.js',
+        'resources/css/index.css',
+      ],
     },
   },
   plugins: [


### PR DESCRIPTION
I really have no strong reasons on this except that Laravel Vite does it this way. We could have a zero js site eventually.