### PR TITLE
Rename wp-json to api

### DIFF
--- a/public/themes/wordplate/functions.php
+++ b/public/themes/wordplate/functions.php
@@ -105,4 +105,4 @@ add_filter('wp_mail_from', fn() => env('MAIL_FROM_ADDRESS', 'hello@example.com')
 add_filter('wp_mail_from_name', fn() => env('MAIL_FROM_NAME', 'Example'));
 
 // Rename wp-json to api.
-add_filter('rest_url_prefix', fn () => 'api');
+add_filter('rest_url_prefix', fn() => 'api');

--- a/public/themes/wordplate/functions.php
+++ b/public/themes/wordplate/functions.php
@@ -103,3 +103,6 @@ add_action('phpmailer_init', function (PHPMailer $mailer) {
 
 add_filter('wp_mail_from', fn() => env('MAIL_FROM_ADDRESS', 'hello@example.com'));
 add_filter('wp_mail_from_name', fn() => env('MAIL_FROM_NAME', 'Example'));
+
+// Rename wp-json to api.
+add_filter('rest_url_prefix', fn () => 'api');

--- a/public/themes/wordplate/functions.php
+++ b/public/themes/wordplate/functions.php
@@ -104,5 +104,5 @@ add_action('phpmailer_init', function (PHPMailer $mailer) {
 add_filter('wp_mail_from', fn() => env('MAIL_FROM_ADDRESS', 'hello@example.com'));
 add_filter('wp_mail_from_name', fn() => env('MAIL_FROM_NAME', 'Example'));
 
-// Rename wp-json to api.
+// Rename /wp-json to /api.
 add_filter('rest_url_prefix', fn() => 'api');


### PR DESCRIPTION
This renames the default _wp-json_ to _api_ instead.